### PR TITLE
Update application_helper.rb

### DIFF
--- a/app/helpers/dynaspan/application_helper.rb
+++ b/app/helpers/dynaspan/application_helper.rb
@@ -59,6 +59,7 @@ module Dynaspan
             choices: options[:choices],                    # For form 'select' field
             options: options.fetch(:options) { Hash.new }, # For form 'select' field
             html_options: options[:html_options],
+            value_to_show: options[:value_to_show],
             block: block
           }
       )


### PR DESCRIPTION
Right now there is no easy option to set the span's value for dynaspan_select and it takes the attribute value. Some weird one like this:
![default](https://user-images.githubusercontent.com/26219298/37566612-9b385de8-2acc-11e8-8dab-cde4ac07b6e8.png)

The pull request will fix that by adding **value_to_show** only for **dynaspan_select**.
