### PR TITLE
Push 0.1.5.1 Version

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Dynaspan also accepts updating an attribute for a nested object, but only 1 leve
 
 ### Installation
 
- - [ ] Add `gem 'dynaspan'` to your Gemfile
+ - [ ] Add `gem "dynaspan", git: "https://github.com/ruslankurmanaleev/dynaspan.git"` to your Gemfile
  - [ ] Run `bundle`
  - [ ] Next add `include Dynaspan::ApplicationHelper` inside your **ApplicationHelper** module
  - [ ] Add `//= require dynaspan/dynaspan` to your **application.js** file
@@ -77,6 +77,7 @@ The options Hash currently has these options.
  - **:html_options** add your own html options to the input field.  Includes ability to add additional classes with `html_options: {class: "example"}`.  **:id**, **:onfocus**, and **:onblur** are reserved.
  - **:choices** used for **dynaspan_select** for the choices of the select box.
  - **:options** used for **dynaspan_select** for the options of the select box; such as **:disabled**, **:prompt**, or **:include_blank**.
+ - **:value_to_show** used for **dynaspan_select** to provide a value for text span (not theselect box)
  - **&block** used only with **dynaspan_select** for passing a block to Rails' form select method.
 
 ### How it updates
@@ -119,6 +120,9 @@ calling parents with selectors.  Example usage:
 
 ### What's New
 
+#### Version 0.1.5.1
+
+Added **value_to_show** parameter to the **dynaspan_select** allowing to set the value for a span.
 
 #### Version 0.1.4 & 0.1.5
 
@@ -134,8 +138,6 @@ Added **dynaspan_select** for having a select box dynamically appear.
  - Added **:choices** used for **dynaspan_select** for the choices of the select box.
  - Added **:options** used for **dynaspan_select** for the options of the select box; such as **:disabled**, **:prompt**, or **:include_blank**.
  - Added **&block** used only with **dynaspan_select** for passing a block to Rails' form select method.
-
-
 
 #### Version 0.1.2
 

--- a/app/helpers/dynaspan/application_helper.rb
+++ b/app/helpers/dynaspan/application_helper.rb
@@ -59,6 +59,7 @@ module Dynaspan
             choices: options[:choices],                    # For form 'select' field
             options: options.fetch(:options) { Hash.new }, # For form 'select' field
             html_options: options[:html_options],
+            value_to_show: options[:value_to_show],
             block: block
           }
       )

--- a/app/views/dynaspan/_dynaspan_text_select.html.erb
+++ b/app/views/dynaspan/_dynaspan_text_select.html.erb
@@ -20,7 +20,11 @@
     <% end %>
   </div>
   <% current_value = attr_object.try(attrib) || master_ds_object.try(attrib) %>
-  <% display_text = begin choices.match(/value="#{current_value}".*>(.+)</)[1] rescue nil end %>
+  <% if value_to_show %>
+    <% display_text = value_to_show %>
+  <% else %>
+    <% display_text = begin choices.match(/value="#{current_value}".*>(.+)</)[1] rescue nil end %>
+  <% end %>
   <%= content_tag 'span', display_text || current_value, id: "dyna_span_span#{unique_ref_id}", onclick: "$().dynaspan.upShow('#{unique_ref_id}');", class: 'dyna-span dyna-span-text', style: 'display:block;' %>
   <%= content_tag('div', dyna_span_edit_text, class: 'dyna-span-edit-text pull-right', onclick: "$().dynaspan.upShow('#{unique_ref_id}');", style: 'cursor:pointer;')  %>
 </div>


### PR DESCRIPTION
Right now there is no easy option to set the span's value for dynaspan_select and it takes the attribute value. Some uninformative _model_id_ like this instead of model's attribute value:
![default](https://user-images.githubusercontent.com/26219298/37566612-9b385de8-2acc-11e8-8dab-cde4ac07b6e8.png)

The pull request will fix that by adding **value_to_show** only for **dynaspan_select**.
